### PR TITLE
Add configurable config path

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,21 @@ docker run -d \
     -v <path to config>:/twitchets/config.yaml \
     --restart unless-stopped \
     arranhs/twitchets:latest
+
+# Specify a custom config path with a flag or env var
+docker run -d \
+    --name twitchets \
+    -v <path to config>:/data/my-config.yaml \
+    --restart unless-stopped \
+    arranhs/twitchets:latest --config /data/my-config.yaml
+
+# Or using the TWITCHETS_CONFIG environment variable
+docker run -d \
+    --name twitchets \
+    -v <path to config>:/data/my-config.yaml \
+    -e TWITCHETS_CONFIG=/data/my-config.yaml \
+    --restart unless-stopped \
+    arranhs/twitchets:latest
 ```
 
 Or, use Docker Compose:
@@ -58,7 +73,8 @@ services:
 
 ## Configuration
 
-twitchets looks for a `config.yaml` file in your current working directory and fails to start if it's not found.
+By default twitchets looks for a `config.yaml` file in the current working directory.
+Use the `--config` flag or `TWITCHETS_CONFIG` environment variable to specify a different location.
 
 The configuration file structure can be seen in [`config.example.yaml`](./config.example.yaml) or below:
 

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"log"
 	"log/slog"
@@ -25,7 +26,10 @@ const (
 	refetchTime   = 1 * time.Minute
 )
 
-var latestTicketTime time.Time
+var (
+	latestTicketTime time.Time
+	configFlag       = flag.String("config", "", "path to config file")
+)
 
 func init() {
 	_ = godotenv.Load()
@@ -44,8 +48,10 @@ func main() {
 		log.Fatalf("failed to get working directory:, %v", err)
 	}
 
+	flag.Parse()
+
 	// Load config
-	configPath := filepath.Join(cwd, "config.yaml")
+	configPath := resolveConfigPath(cwd)
 	conf, err := config.Load(configPath)
 	if err != nil {
 		log.Fatalf("config error:, %v", err)
@@ -275,4 +281,17 @@ func changeZeroToNegative(value float64) float64 {
 		return -1.0
 	}
 	return value
+}
+
+func resolveConfigPath(cwd string) string {
+	if *configFlag != "" {
+		return *configFlag
+	}
+
+	envPath := os.Getenv("TWITCHETS_CONFIG")
+	if envPath != "" {
+		return envPath
+	}
+
+	return filepath.Join(cwd, "config.yaml")
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveConfigPath_Default(t *testing.T) {
+	path := resolveConfigPath("/cwd")
+	require.Equal(t, "/cwd/config.yaml", path)
+}
+
+func TestResolveConfigPath_Flag(t *testing.T) {
+	*configFlag = "/flag/config.yaml"
+	path := resolveConfigPath("/cwd")
+	require.Equal(t, "/flag/config.yaml", path)
+	*configFlag = ""
+}
+
+func TestResolveConfigPath_Env(t *testing.T) {
+	t.Setenv("TWITCHETS_CONFIG", "/env/config.yaml")
+	path := resolveConfigPath("/cwd")
+	require.Equal(t, "/env/config.yaml", path)
+}
+
+func TestResolveConfigPath_FlagOverridesEnv(t *testing.T) {
+	*configFlag = "/flag/config.yaml"
+	t.Setenv("TWITCHETS_CONFIG", "/env/config.yaml")
+	path := resolveConfigPath("/cwd")
+	require.Equal(t, "/flag/config.yaml", path)
+	*configFlag = ""
+}


### PR DESCRIPTION
## Summary
- allow setting config file path via `--config` flag or `TWITCHETS_CONFIG` env var
- document how to pass the path when running the container
- cover config path resolution logic with unit tests

## Testing
- `go test ./...` *(fails: access to modules blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6887aaffd3888325a47c52b48d6f6bc7