### PR TITLE
Make ticket fetch interval configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ apiKey: <your twickets api key> # REQUIRED: See README.md for details on how to 
 
 country: GB # Currently only GB is supported
 
+# Number of seconds between checking for new tickets
+refetchIntervalSeconds: 60
+
 # Notification service configuration
 # Remove/comment out services you don't need
 notification:

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -2,6 +2,9 @@ apiKey: <your twickets api key> # REQUIRED: See README.md for details on how to 
 
 country: GB # Currently only GB is supported
 
+# Number of seconds between checking for new tickets
+refetchIntervalSeconds: 60
+
 # Notification service configuration
 # Remove/comment out services you don't need
 notification:

--- a/config/config.go
+++ b/config/config.go
@@ -8,11 +8,12 @@ import (
 )
 
 type Config struct {
-	APIKey             string                    `json:"apiKey"`
-	Country            twigots.Country           `json:"country"`
-	Notification       NotificationConfig        `json:"notification"`
-	GlobalTicketConfig GlobalTicketListingConfig `json:"global"`
-	TicketConfigs      []TicketListingConfig     `json:"tickets"`
+	APIKey                 string                    `json:"apiKey"`
+	Country                twigots.Country           `json:"country"`
+	RefetchIntervalSeconds int                       `json:"refetchIntervalSeconds"`
+	Notification           NotificationConfig        `json:"notification"`
+	GlobalTicketConfig     GlobalTicketListingConfig `json:"global"`
+	TicketConfigs          []TicketListingConfig     `json:"tickets"`
 }
 
 func (c Config) Validate() error {
@@ -25,6 +26,10 @@ func (c Config) Validate() error {
 	}
 	if !twigots.Countries.Contains(c.Country) {
 		return fmt.Errorf("country '%s' is not valid", c.Country)
+	}
+
+	if c.RefetchIntervalSeconds < 1 {
+		return errors.New("refetch interval must be at least 1 second")
 	}
 
 	err := c.Notification.Validate()

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -25,8 +25,9 @@ func TestLoadConfig(t *testing.T) { // nolint: revive
 	globalDiscount := 25.0
 
 	expectedConfig := config.Config{
-		APIKey:  "test",
-		Country: country,
+		APIKey:                 "test",
+		Country:                country,
+		RefetchIntervalSeconds: 60,
 		GlobalTicketConfig: config.GlobalTicketListingConfig{
 			EventSimilarity:       globalEventSimilarity,
 			Regions:               globalRegions,

--- a/config/load.go
+++ b/config/load.go
@@ -54,6 +54,10 @@ func parseKoanf(k *koanf.Koanf) (Config, error) {
 		return Config{}, fmt.Errorf("failed to unmarshal config: %w", err)
 	}
 
+	if config.RefetchIntervalSeconds == 0 {
+		config.RefetchIntervalSeconds = 60
+	}
+
 	err = config.Validate()
 	if err != nil {
 		return Config{}, fmt.Errorf("invalid config: %w", err)

--- a/main.go
+++ b/main.go
@@ -23,7 +23,6 @@ import (
 
 const (
 	maxNumTickets = 250
-	refetchTime   = 1 * time.Minute
 )
 
 var (
@@ -81,6 +80,7 @@ func main() {
 	fetchAndProcessTickets(client, notificationClients, listingConfigs)
 
 	// Create ticker
+	refetchTime := time.Duration(conf.RefetchIntervalSeconds) * time.Second
 	ticker := time.NewTicker(refetchTime)
 	defer ticker.Stop()
 


### PR DESCRIPTION
## Summary
- allow configuring refetch interval in seconds via `refetchIntervalSeconds`
- use configured interval when scheduling ticket fetches
- document the new configuration option

## Testing
- `go test ./...`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_688e741e9e5c832584d2e22bfb92e8b1