### PR TITLE
Add SQS notification client

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Powered by [twigots](https://github.com/ahobsonsayers/twigots), a Go package to 
 - Show more details in the notifications, such as event date/time, number of tickets, and discount
 - Faster notifications than the official Twickets app
 - No need to have the Twickets app or an account
-- Choose from various notification services (Telegram, Ntfy, Gotify currently supported)
+- Choose from various notification services (Telegram, Ntfy, Gotify, SQS currently supported)
 
 ## Getting an API Key
 
@@ -103,6 +103,12 @@ notification:
     url: <your gotify url> # Your Gotify server URL
     token: <your gotify api token> # Application token from Gotify
 
+  sqs:
+    queueUrl: <your sqs queue url> # AWS SQS queue URL
+    region: <your aws region> # AWS region, e.g. eu-west-1
+    accessKeyId: <your aws access key id> # Optional: AWS access key
+    secretAccessKey: <your aws secret access key> # Optional: AWS secret key
+
 # Global ticket configuration
 # All available settings are outlined below
 # These settings apply to all tickets by default
@@ -136,6 +142,7 @@ global:
   # Default: All configured services
   notification:
     - ntfy
+    # - sqs
 
 # Individual ticket configuration
 # Available settings match the global ones

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -22,6 +22,12 @@ notification:
     url: <your gotify url> # Your Gotify server URL
     token: <your gotify api token> # Application token from Gotify
 
+  sqs:
+    queueUrl: <your sqs queue url> # AWS SQS queue URL
+    region: <your aws region> # AWS region, e.g. eu-west-1
+    accessKeyId: <your aws access key id> # Optional: AWS access key
+    secretAccessKey: <your aws secret access key> # Optional: AWS secret key
+
 # Global ticket configuration
 # All available settings are outlined below
 # These settings apply to all tickets by default
@@ -55,6 +61,7 @@ global:
   # Default: All configured services
   notification:
     - ntfy
+    # - sqs
 
 # Individual ticket configuration
 # Available settings match the global ones

--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,14 @@ module github.com/ahobsonsayers/twitchets
 go 1.24
 
 require (
-	github.com/ahobsonsayers/twigots v0.6.0
-	github.com/go-telegram-bot-api/telegram-bot-api/v5 v5.5.1
-	github.com/gotify/go-api-client/v2 v2.0.4
-	github.com/joho/godotenv v1.5.1
+        github.com/ahobsonsayers/twigots v0.6.0
+       github.com/aws/aws-sdk-go-v2 v1.9.2
+       github.com/aws/aws-sdk-go-v2/config v1.8.3
+       github.com/aws/aws-sdk-go-v2/credentials v1.4.3
+       github.com/aws/aws-sdk-go-v2/service/sqs v1.9.2
+        github.com/go-telegram-bot-api/telegram-bot-api/v5 v5.5.1
+        github.com/gotify/go-api-client/v2 v2.0.4
+        github.com/joho/godotenv v1.5.1
 	github.com/knadh/koanf v1.5.0
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/orsinium-labs/enum v1.4.0

--- a/notification/sqs.go
+++ b/notification/sqs.go
@@ -1,0 +1,66 @@
+package notification
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ahobsonsayers/twigots"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/sqs"
+)
+
+type SqsClient struct {
+	queueUrl string
+	client   *sqs.Client
+}
+
+var _ Client = SqsClient{}
+
+func (c SqsClient) SendTicketNotification(ticket twigots.TicketListing) error {
+	message, err := RenderMessage(ticket, WithHeader(), WithFooter())
+	if err != nil {
+		return err
+	}
+
+	_, err = c.client.SendMessage(context.Background(), &sqs.SendMessageInput{
+		QueueUrl:    &c.queueUrl,
+		MessageBody: aws.String(message),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to send sqs message: %w", err)
+	}
+
+	return nil
+}
+
+type SqsConfig struct {
+	QueueUrl        string `json:"queueUrl"`
+	Region          string `json:"region"`
+	AccessKeyID     string `json:"accessKeyId"`
+	SecretAccessKey string `json:"secretAccessKey"`
+}
+
+func NewSqsClient(cfg SqsConfig) (SqsClient, error) {
+	loadOptions := []func(*awsconfig.LoadOptions) error{
+		awsconfig.WithRegion(cfg.Region),
+	}
+	if cfg.AccessKeyID != "" && cfg.SecretAccessKey != "" {
+		loadOptions = append(loadOptions, awsconfig.WithCredentialsProvider(
+			credentials.NewStaticCredentialsProvider(cfg.AccessKeyID, cfg.SecretAccessKey, ""),
+		))
+	}
+
+	awsCfg, err := awsconfig.LoadDefaultConfig(context.Background(), loadOptions...)
+	if err != nil {
+		return SqsClient{}, fmt.Errorf("failed to load aws config: %w", err)
+	}
+
+	sqsClient := sqs.NewFromConfig(awsCfg)
+
+	return SqsClient{
+		queueUrl: cfg.QueueUrl,
+		client:   sqsClient,
+	}, nil
+}

--- a/notification/sqs_test.go
+++ b/notification/sqs_test.go
@@ -1,0 +1,41 @@
+package notification_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/ahobsonsayers/twitchets/notification"
+	"github.com/ahobsonsayers/twitchets/test"
+	"github.com/joho/godotenv"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSqsSendTicketMessage(t *testing.T) {
+	t.Skip("Can only be run manually locally with environment variables set. Comment to run.")
+
+	_ = godotenv.Load(test.ProjectDirectoryJoin(t, ".env"))
+
+	queueUrl := os.Getenv("SQS_QUEUE_URL")
+	require.NotEmpty(t, queueUrl, "SQS_QUEUE_URL is not set")
+
+	region := os.Getenv("AWS_REGION")
+	require.NotEmpty(t, region, "AWS_REGION is not set")
+
+	accessKeyID := os.Getenv("AWS_ACCESS_KEY_ID")
+	require.NotEmpty(t, accessKeyID, "AWS_ACCESS_KEY_ID is not set")
+
+	secretAccessKey := os.Getenv("AWS_SECRET_ACCESS_KEY")
+	require.NotEmpty(t, secretAccessKey, "AWS_SECRET_ACCESS_KEY is not set")
+
+	client, err := notification.NewSqsClient(notification.SqsConfig{
+		QueueUrl:        queueUrl,
+		Region:          region,
+		AccessKeyID:     accessKeyID,
+		SecretAccessKey: secretAccessKey,
+	})
+	require.NoError(t, err)
+
+	ticket := testNotificationTicket()
+	err = client.SendTicketNotification(ticket)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
## Summary
- support SQS notifications via new `SqsClient`
- wire SQS configuration and client creation into notification config
- document SQS usage and add manual test

## Testing
- `go mod tidy` *(fails: module downloads forbidden)*
- `go test ./...` *(fails: missing go.sum entry for aws modules)*


------
https://chatgpt.com/codex/tasks/task_e_688fb900a75883259a8c0474b498a883