### PR TITLE
Send only ticket URL in SQS notification

### DIFF
--- a/notification/sqs.go
+++ b/notification/sqs.go
@@ -19,14 +19,9 @@ type SqsClient struct {
 var _ Client = SqsClient{}
 
 func (c SqsClient) SendTicketNotification(ticket twigots.TicketListing) error {
-	message, err := RenderMessage(ticket, WithHeader(), WithFooter())
-	if err != nil {
-		return err
-	}
-
-	_, err = c.client.SendMessage(context.Background(), &sqs.SendMessageInput{
+	_, err := c.client.SendMessage(context.Background(), &sqs.SendMessageInput{
 		QueueUrl:    &c.queueUrl,
-		MessageBody: aws.String(message),
+		MessageBody: aws.String(ticket.URL()),
 	})
 	if err != nil {
 		return fmt.Errorf("failed to send sqs message: %w", err)


### PR DESCRIPTION
## Summary
- send ticket URL only in SQS message

## Testing
- `go test ./...` *(fails: missing go.sum entries for AWS modules)*
- `go mod tidy` *(fails: downloading modules forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6890d35820c08325b2dfb0cd4603a649